### PR TITLE
Return ref from enc ciphertext

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1795,7 +1795,6 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.4.0"
-source = "git+https://github.com/QED-it/zcash_note_encryption?branch=zsa1#58384553aab76b2ee6d6eb328cf2187fa824ec9a"
 dependencies = [
  "chacha20",
  "chacha20poly1305",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1795,7 +1795,7 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.4.0"
-source = "git+https://github.com/QED-it/zcash_note_encryption?branch=return-ref-from-enc-ciphertext#3a54c7281bacf59fe8dcffc6d9b82db60ae465f6"
+source = "git+https://github.com/QED-it/zcash_note_encryption?branch=zsa1#76745f00551d4442dee11ad64a8400b75132d18f"
 dependencies = [
  "chacha20",
  "chacha20poly1305",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1795,6 +1795,7 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.4.0"
+source = "git+https://github.com/QED-it/zcash_note_encryption?branch=return-ref-from-enc-ciphertext#3a54c7281bacf59fe8dcffc6d9b82db60ae465f6"
 dependencies = [
  "chacha20",
  "chacha20poly1305",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ bitvec = "1"
 incrementalmerkletree = { version = "0.5", features = ["legacy-api"] }
 
 # Note encryption
-zcash_note_encryption = { version = "0.4", features = ["pre-zip-212"] }
+zcash_note_encryption = { version = "0.4", path = "../zcash_note_encryption", features = ["pre-zip-212"] }
 
 # Secret management
 subtle = "2.2.3"
@@ -104,4 +104,4 @@ name = "pedersen_hash"
 harness = false
 
 [patch.crates-io]
-zcash_note_encryption = { version = "0.4", git = "https://github.com/QED-it/zcash_note_encryption", branch = "zsa1"  }
+#zcash_note_encryption = { version = "0.4", git = "https://github.com/QED-it/zcash_note_encryption", branch = "zsa1"  }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,7 @@ bitvec = "1"
 incrementalmerkletree = { version = "0.5", features = ["legacy-api"] }
 
 # Note encryption
-zcash_note_encryption = { version = "0.4", path = "../zcash_note_encryption", features = ["pre-zip-212"] }
+zcash_note_encryption = { version = "0.4", features = ["pre-zip-212"] }
 
 # Secret management
 subtle = "2.2.3"
@@ -104,4 +104,4 @@ name = "pedersen_hash"
 harness = false
 
 [patch.crates-io]
-#zcash_note_encryption = { version = "0.4", git = "https://github.com/QED-it/zcash_note_encryption", branch = "zsa1"  }
+zcash_note_encryption = { version = "0.4", git = "https://github.com/QED-it/zcash_note_encryption", branch = "return-ref-from-enc-ciphertext"  }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,4 +104,4 @@ name = "pedersen_hash"
 harness = false
 
 [patch.crates-io]
-zcash_note_encryption = { version = "0.4", git = "https://github.com/QED-it/zcash_note_encryption", branch = "return-ref-from-enc-ciphertext"  }
+zcash_note_encryption = { version = "0.4", git = "https://github.com/QED-it/zcash_note_encryption", branch = "zsa1" }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -15,7 +15,7 @@ use crate::{
     },
     circuit,
     keys::{OutgoingViewingKey, SpendAuthorizingKey, SpendValidatingKey},
-    note_encryption::{sapling_note_encryption, Zip212Enforcement},
+    note_encryption::{sapling_note_encryption, Zip212Enforcement, MEMO_SIZE},
     prover::{OutputProver, SpendProver},
     util::generate_random_rseed_internal,
     value::{
@@ -281,7 +281,7 @@ pub struct OutputInfo {
     ovk: Option<OutgoingViewingKey>,
     to: PaymentAddress,
     value: NoteValue,
-    memo: [u8; 512],
+    memo: [u8; MEMO_SIZE],
 }
 
 impl OutputInfo {
@@ -290,14 +290,14 @@ impl OutputInfo {
         ovk: Option<OutgoingViewingKey>,
         to: PaymentAddress,
         value: NoteValue,
-        memo: Option<[u8; 512]>,
+        memo: Option<[u8; MEMO_SIZE]>,
     ) -> Self {
         Self {
             ovk,
             to,
             value,
             memo: memo.unwrap_or_else(|| {
-                let mut memo = [0; 512];
+                let mut memo = [0; MEMO_SIZE];
                 memo[0] = 0xf6;
                 memo
             }),
@@ -353,7 +353,7 @@ struct PreparedOutputInfo {
     /// `None` represents the `ovk = ⊥` case.
     ovk: Option<OutgoingViewingKey>,
     note: Note,
-    memo: [u8; 512],
+    memo: [u8; MEMO_SIZE],
     rcv: ValueCommitTrapdoor,
 }
 
@@ -523,7 +523,7 @@ impl Builder {
         ovk: Option<OutgoingViewingKey>,
         to: PaymentAddress,
         value: NoteValue,
-        memo: Option<[u8; 512]>,
+        memo: Option<[u8; MEMO_SIZE]>,
     ) -> Result<(), Error> {
         let output = OutputInfo::new(ovk, to, value, memo);
 

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -5,7 +5,7 @@ use memuse::DynamicUsage;
 use redjubjub::{Binding, SpendAuth};
 
 use zcash_note_encryption::{
-    note_bytes::NoteBytesData, Domain, EphemeralKeyBytes, ShieldedOutput, OUT_CIPHERTEXT_SIZE,
+    note_bytes::NoteBytesData, EphemeralKeyBytes, ShieldedOutput, OUT_CIPHERTEXT_SIZE,
 };
 
 use crate::{
@@ -343,7 +343,7 @@ impl<Proof> OutputDescription<Proof> {
     }
 
     /// Returns the encrypted note ciphertext.
-    pub fn enc_ciphertext(&self) -> &<SaplingDomain as Domain>::NoteCiphertextBytes {
+    pub fn enc_ciphertext(&self) -> &NoteBytesData<{ ENC_CIPHERTEXT_SIZE }> {
         &self.enc_ciphertext
     }
 
@@ -415,11 +415,11 @@ impl<A> ShieldedOutput<SaplingDomain> for OutputDescription<A> {
         self.cmu.to_bytes()
     }
 
-    fn enc_ciphertext(&self) -> Option<&<SaplingDomain as Domain>::NoteCiphertextBytes> {
+    fn enc_ciphertext(&self) -> Option<&NoteBytesData<{ ENC_CIPHERTEXT_SIZE }>> {
         Some(&self.enc_ciphertext)
     }
 
-    fn enc_ciphertext_compact(&self) -> <SaplingDomain as Domain>::CompactNoteCiphertextBytes {
+    fn enc_ciphertext_compact(&self) -> NoteBytesData<{ COMPACT_NOTE_SIZE }> {
         unimplemented!("This function is not required for sapling")
     }
 }

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -321,7 +321,7 @@ pub struct OutputDescription<Proof> {
     cv: ValueCommitment,
     cmu: ExtractedNoteCommitment,
     ephemeral_key: EphemeralKeyBytes,
-    enc_ciphertext: [u8; ENC_CIPHERTEXT_SIZE],
+    enc_ciphertext: NoteBytesData<{ ENC_CIPHERTEXT_SIZE }>,
     out_ciphertext: [u8; OUT_CIPHERTEXT_SIZE],
     zkproof: Proof,
 }
@@ -342,7 +342,7 @@ impl<Proof> OutputDescription<Proof> {
     }
 
     /// Returns the encrypted note ciphertext.
-    pub fn enc_ciphertext(&self) -> &[u8; ENC_CIPHERTEXT_SIZE] {
+    pub fn enc_ciphertext(&self) -> &<SaplingDomain as Domain>::NoteCiphertextBytes {
         &self.enc_ciphertext
     }
 
@@ -369,7 +369,7 @@ impl<Proof> OutputDescription<Proof> {
             cv,
             cmu,
             ephemeral_key,
-            enc_ciphertext,
+            enc_ciphertext: NoteBytesData(enc_ciphertext),
             out_ciphertext,
             zkproof,
         }
@@ -388,7 +388,7 @@ impl<Proof> OutputDescription<Proof> {
         &mut self.ephemeral_key
     }
     pub(crate) fn enc_ciphertext_mut(&mut self) -> &mut [u8; ENC_CIPHERTEXT_SIZE] {
-        &mut self.enc_ciphertext
+        &mut self.enc_ciphertext.0
     }
     pub(crate) fn out_ciphertext_mut(&mut self) -> &mut [u8; OUT_CIPHERTEXT_SIZE] {
         &mut self.out_ciphertext
@@ -414,8 +414,8 @@ impl<A> ShieldedOutput<SaplingDomain> for OutputDescription<A> {
         self.cmu.to_bytes()
     }
 
-    fn enc_ciphertext(&self) -> Option<<SaplingDomain as Domain>::NoteCiphertextBytes> {
-        Some(NoteBytesData(self.enc_ciphertext))
+    fn enc_ciphertext(&self) -> Option<&<SaplingDomain as Domain>::NoteCiphertextBytes> {
+        Some(&self.enc_ciphertext)
     }
 
     fn enc_ciphertext_compact(&self) -> <SaplingDomain as Domain>::CompactNoteCiphertextBytes {
@@ -470,7 +470,7 @@ impl OutputDescriptionV5 {
             cv: self.cv,
             cmu: self.cmu,
             ephemeral_key: self.ephemeral_key,
-            enc_ciphertext: self.enc_ciphertext,
+            enc_ciphertext: NoteBytesData(self.enc_ciphertext),
             out_ciphertext: self.out_ciphertext,
             zkproof,
         }
@@ -482,7 +482,9 @@ impl<A> From<OutputDescription<A>> for CompactOutputDescription {
         CompactOutputDescription {
             ephemeral_key: out.ephemeral_key,
             cmu: out.cmu,
-            enc_ciphertext: out.enc_ciphertext[..COMPACT_NOTE_SIZE].try_into().unwrap(),
+            enc_ciphertext: out.enc_ciphertext.as_ref()[..COMPACT_NOTE_SIZE]
+                .try_into()
+                .unwrap(),
         }
     }
 }
@@ -509,7 +511,7 @@ pub mod testing {
     };
 
     use super::{
-        Authorized, Bundle, GrothProofBytes, OutputDescription, SpendDescription,
+        Authorized, Bundle, GrothProofBytes, NoteBytesData, OutputDescription, SpendDescription,
         ENC_CIPHERTEXT_SIZE, OUT_CIPHERTEXT_SIZE,
     };
 
@@ -572,7 +574,7 @@ pub mod testing {
                 cv,
                 cmu,
                 ephemeral_key: epk.to_bytes().into(),
-                enc_ciphertext,
+                enc_ciphertext: NoteBytesData(enc_ciphertext),
                 out_ciphertext,
                 zkproof,
             }

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -5,14 +5,15 @@ use memuse::DynamicUsage;
 use redjubjub::{Binding, SpendAuth};
 
 use zcash_note_encryption::{
-    note_bytes::NoteBytesData, Domain, EphemeralKeyBytes, ShieldedOutput, COMPACT_NOTE_SIZE,
-    ENC_CIPHERTEXT_SIZE, OUT_CIPHERTEXT_SIZE,
+    note_bytes::NoteBytesData, Domain, EphemeralKeyBytes, ShieldedOutput, OUT_CIPHERTEXT_SIZE,
 };
 
 use crate::{
     circuit::GROTH_PROOF_SIZE,
     note::ExtractedNoteCommitment,
-    note_encryption::{CompactOutputDescription, SaplingDomain},
+    note_encryption::{
+        CompactOutputDescription, SaplingDomain, COMPACT_NOTE_SIZE, ENC_CIPHERTEXT_SIZE,
+    },
     value::ValueCommitment,
     Nullifier,
 };

--- a/src/note_encryption.rs
+++ b/src/note_encryption.rs
@@ -12,9 +12,20 @@ use zcash_note_encryption::{
     note_bytes::{NoteBytes, NoteBytesData},
     try_compact_note_decryption, try_note_decryption, try_output_recovery_with_ock,
     try_output_recovery_with_ovk, BatchDomain, Domain, EphemeralKeyBytes, NoteEncryption,
-    OutPlaintextBytes, OutgoingCipherKey, ShieldedOutput, COMPACT_NOTE_SIZE, ENC_CIPHERTEXT_SIZE,
-    NOTE_PLAINTEXT_SIZE, OUT_PLAINTEXT_SIZE,
+    OutPlaintextBytes, OutgoingCipherKey, ShieldedOutput, AEAD_TAG_SIZE, OUT_PLAINTEXT_SIZE,
 };
+
+/// The size of a compact note.
+pub const COMPACT_NOTE_SIZE: usize = 1 + // version
+    11 + // diversifier
+    8  + // value
+    32; // rseed (or rcm prior to ZIP 212)
+
+/// The size of [`Domain::NotePlaintextBytes`].
+pub const NOTE_PLAINTEXT_SIZE: usize = COMPACT_NOTE_SIZE + 512;
+
+/// The size of an encrypted note plaintext.
+pub const ENC_CIPHERTEXT_SIZE: usize = NOTE_PLAINTEXT_SIZE + AEAD_TAG_SIZE;
 
 use crate::{
     bundle::{GrothProofBytes, OutputDescription},

--- a/src/note_encryption.rs
+++ b/src/note_encryption.rs
@@ -497,8 +497,8 @@ mod tests {
     use rand_core::{CryptoRng, RngCore};
 
     use zcash_note_encryption::{
-        batch, EphemeralKeyBytes, NoteEncryption, OutgoingCipherKey, ENC_CIPHERTEXT_SIZE,
-        NOTE_PLAINTEXT_SIZE, OUT_CIPHERTEXT_SIZE, OUT_PLAINTEXT_SIZE,
+        batch, EphemeralKeyBytes, NoteEncryption, OutgoingCipherKey, OUT_CIPHERTEXT_SIZE,
+        OUT_PLAINTEXT_SIZE,
     };
 
     use super::{
@@ -513,7 +513,7 @@ mod tests {
         circuit::GROTH_PROOF_SIZE,
         keys::{DiversifiedTransmissionKey, EphemeralSecretKey, OutgoingViewingKey},
         note::ExtractedNoteCommitment,
-        note_encryption::PreparedIncomingViewingKey,
+        note_encryption::{PreparedIncomingViewingKey, ENC_CIPHERTEXT_SIZE, NOTE_PLAINTEXT_SIZE},
         util::generate_random_rseed,
         value::{NoteValue, ValueCommitTrapdoor, ValueCommitment},
         Diversifier, PaymentAddress, Rseed, SaplingIvk,

--- a/src/note_encryption.rs
+++ b/src/note_encryption.rs
@@ -362,11 +362,11 @@ impl ShieldedOutput<SaplingDomain> for CompactOutputDescription {
         self.cmu.to_bytes()
     }
 
-    fn enc_ciphertext(&self) -> Option<&<SaplingDomain as Domain>::NoteCiphertextBytes> {
+    fn enc_ciphertext(&self) -> Option<&NoteBytesData<{ ENC_CIPHERTEXT_SIZE }>> {
         None
     }
 
-    fn enc_ciphertext_compact(&self) -> <SaplingDomain as Domain>::CompactNoteCiphertextBytes {
+    fn enc_ciphertext_compact(&self) -> NoteBytesData<{ COMPACT_NOTE_SIZE }> {
         NoteBytesData::from_slice(self.enc_ciphertext.as_ref()).unwrap()
     }
 }

--- a/src/note_encryption.rs
+++ b/src/note_encryption.rs
@@ -16,7 +16,7 @@ use zcash_note_encryption::{
 };
 
 /// The size of the memo.
-pub(crate) const MEMO_SIZE: usize = 512;
+pub const MEMO_SIZE: usize = 512;
 
 /// The size of a compact note.
 pub const COMPACT_NOTE_SIZE: usize = 1 + // version

--- a/src/note_encryption.rs
+++ b/src/note_encryption.rs
@@ -388,7 +388,7 @@ impl ShieldedOutput<SaplingDomain> for CompactOutputDescription {
 /// use rand_core::OsRng;
 /// use sapling_crypto::{
 ///     keys::OutgoingViewingKey,
-///     note_encryption::{sapling_note_encryption, Zip212Enforcement},
+///     note_encryption::{sapling_note_encryption, Zip212Enforcement, MEMO_SIZE},
 ///     util::generate_random_rseed,
 ///     value::{NoteValue, ValueCommitTrapdoor, ValueCommitment},
 ///     Diversifier, PaymentAddress, Rseed, SaplingIvk,


### PR DESCRIPTION
This PR updates the `ShieldedOutput` implementation and `OutputDescription` struct to align with the recent changes in the `zcash_note_encryption` crate. Specifically, the `enc_ciphertext` method now returns a reference instead of a copy. Also, it changed `enc_ciphertext` storage in `OutputDescription` to `NoteBytesData`.

This change was discussed and suggested in PR zcash/zcash_note_encryption#2 review.

