### PR TITLE
Reduce diff with upstream

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1825,7 +1825,7 @@ dependencies = [
 [[package]]
 name = "zcash_note_encryption"
 version = "0.4.1"
-source = "git+https://github.com/zcash/zcash_note_encryption?branch=main#9f7e93d42cef839d02b9d75918117941d453f8cb"
+source = "git+https://github.com/zcash/zcash_note_encryption?rev=9f7e93d42cef839d02b9d75918117941d453f8cb#9f7e93d42cef839d02b9d75918117941d453f8cb"
 dependencies = [
  "chacha20",
  "chacha20poly1305",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,4 +126,4 @@ name = "pedersen_hash"
 harness = false
 
 [patch.crates-io]
-zcash_note_encryption = { version = "0.4.1", git = "https://github.com/zcash/zcash_note_encryption", branch = "main" }
+zcash_note_encryption = { git = "https://github.com/zcash/zcash_note_encryption", rev = "9f7e93d42cef839d02b9d75918117941d453f8cb" }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -368,17 +368,13 @@ impl OutputInfo {
         ovk: Option<OutgoingViewingKey>,
         to: PaymentAddress,
         value: NoteValue,
-        memo: Option<[u8; MEMO_SIZE]>,
+        memo: [u8; MEMO_SIZE],
     ) -> Self {
         Self {
             ovk,
             to,
             value,
-            memo: memo.unwrap_or_else(|| {
-                let mut memo = [0; MEMO_SIZE];
-                memo[0] = 0xf6;
-                memo
-            }),
+            memo,
         }
     }
 
@@ -406,7 +402,7 @@ impl OutputInfo {
             }
         };
 
-        Self::new(None, dummy_to, NoteValue::ZERO, None)
+        Self::new(None, dummy_to, NoteValue::ZERO, [0u8; 512])
     }
 
     fn prepare<R: RngCore>(
@@ -660,7 +656,7 @@ impl Builder {
         ovk: Option<OutgoingViewingKey>,
         to: PaymentAddress,
         value: NoteValue,
-        memo: Option<[u8; MEMO_SIZE]>,
+        memo: [u8; MEMO_SIZE],
     ) -> Result<(), Error> {
         let output = OutputInfo::new(ovk, to, value, memo);
 


### PR DESCRIPTION
- Use `rev` instead of a branch in the patch section of `Cargo.toml` (to match our other repositories)
- Remove `Option` from `memo`