### PR TITLE
Address review comments from zcash PR #177

### DIFF
--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -13,7 +13,8 @@ use crate::{
     constants::GROTH_PROOF_SIZE,
     note::ExtractedNoteCommitment,
     note_encryption::{
-        CompactOutputDescription, SaplingDomain, COMPACT_NOTE_SIZE, ENC_CIPHERTEXT_SIZE,EncCiphertext, CompactEncCiphertext
+        CompactEncCiphertext, CompactOutputDescription, EncCiphertext, SaplingDomain,
+        COMPACT_NOTE_SIZE, ENC_CIPHERTEXT_SIZE,
     },
     value::ValueCommitment,
     Nullifier,

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -13,7 +13,7 @@ use crate::{
     constants::GROTH_PROOF_SIZE,
     note::ExtractedNoteCommitment,
     note_encryption::{
-        CompactOutputDescription, SaplingDomain, COMPACT_NOTE_SIZE, ENC_CIPHERTEXT_SIZE,
+        CompactOutputDescription, SaplingDomain, COMPACT_NOTE_SIZE, ENC_CIPHERTEXT_SIZE,EncCiphertext, CompactEncCiphertext
     },
     value::ValueCommitment,
     Nullifier,
@@ -419,9 +419,6 @@ impl<Proof: DynamicUsage> DynamicUsage for OutputDescription<Proof> {
         self.zkproof.dynamic_usage_bounds()
     }
 }
-
-type EncCiphertext = NoteBytesData<{ ENC_CIPHERTEXT_SIZE }>;
-type CompactEncCiphertext = NoteBytesData<{ COMPACT_NOTE_SIZE }>;
 
 impl<A> ShieldedOutput<SaplingDomain> for OutputDescription<A> {
     fn ephemeral_key(&self) -> EphemeralKeyBytes {

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -420,6 +420,9 @@ impl<Proof: DynamicUsage> DynamicUsage for OutputDescription<Proof> {
     }
 }
 
+type EncCiphertext = NoteBytesData<{ ENC_CIPHERTEXT_SIZE }>;
+type CompactEncCiphertext = NoteBytesData<{ COMPACT_NOTE_SIZE }>;
+
 impl<A> ShieldedOutput<SaplingDomain> for OutputDescription<A> {
     fn ephemeral_key(&self) -> EphemeralKeyBytes {
         self.ephemeral_key.clone()
@@ -433,11 +436,11 @@ impl<A> ShieldedOutput<SaplingDomain> for OutputDescription<A> {
         self.cmu.to_bytes()
     }
 
-    fn enc_ciphertext(&self) -> Option<&NoteBytesData<{ ENC_CIPHERTEXT_SIZE }>> {
+    fn enc_ciphertext(&self) -> Option<&EncCiphertext> {
         Some(&self.enc_ciphertext)
     }
 
-    fn enc_ciphertext_compact(&self) -> NoteBytesData<{ COMPACT_NOTE_SIZE }> {
+    fn enc_ciphertext_compact(&self) -> CompactEncCiphertext {
         unimplemented!("This function is not required for sapling")
     }
 }

--- a/src/bundle.rs
+++ b/src/bundle.rs
@@ -441,7 +441,9 @@ impl<A> ShieldedOutput<SaplingDomain> for OutputDescription<A> {
     }
 
     fn enc_ciphertext_compact(&self) -> CompactEncCiphertext {
-        unimplemented!("This function is not required for sapling")
+        let mut data = [0u8; COMPACT_NOTE_SIZE];
+        data.copy_from_slice(&self.enc_ciphertext.as_ref()[..COMPACT_NOTE_SIZE]);
+        NoteBytesData(data)
     }
 }
 
@@ -501,12 +503,12 @@ impl OutputDescriptionV5 {
 
 impl<A> From<OutputDescription<A>> for CompactOutputDescription {
     fn from(out: OutputDescription<A>) -> CompactOutputDescription {
+        let enc_ciphertext = out.enc_ciphertext_compact().0;
+
         CompactOutputDescription {
             ephemeral_key: out.ephemeral_key,
             cmu: out.cmu,
-            enc_ciphertext: out.enc_ciphertext.as_ref()[..COMPACT_NOTE_SIZE]
-                .try_into()
-                .unwrap(),
+            enc_ciphertext,
         }
     }
 }

--- a/src/note_encryption.rs
+++ b/src/note_encryption.rs
@@ -140,6 +140,9 @@ impl SaplingDomain {
     }
 }
 
+pub(crate) type EncCiphertext = NoteBytesData<{ ENC_CIPHERTEXT_SIZE }>;
+pub(crate) type CompactEncCiphertext = NoteBytesData<{ COMPACT_NOTE_SIZE }>;
+
 impl Domain for SaplingDomain {
     type EphemeralSecretKey = EphemeralSecretKey;
     // It is acceptable for this to be a point rather than a byte array, because we
@@ -160,9 +163,9 @@ impl Domain for SaplingDomain {
     type Memo = [u8; MEMO_SIZE];
 
     type NotePlaintextBytes = NoteBytesData<{ NOTE_PLAINTEXT_SIZE }>;
-    type NoteCiphertextBytes = NoteBytesData<{ ENC_CIPHERTEXT_SIZE }>;
+    type NoteCiphertextBytes = EncCiphertext;
     type CompactNotePlaintextBytes = NoteBytesData<{ COMPACT_NOTE_SIZE }>;
-    type CompactNoteCiphertextBytes = NoteBytesData<{ COMPACT_NOTE_SIZE }>;
+    type CompactNoteCiphertextBytes = CompactEncCiphertext;
 
     fn derive_esk(note: &Self::Note) -> Option<Self::EphemeralSecretKey> {
         note.derive_esk()


### PR DESCRIPTION
- Add type aliases for `EncCiphertext` and `CompactEncCiphertext`
- Implement `enc_ciphertext_compact` for `OutputDescription`